### PR TITLE
Fix delay when stopping the docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.4.2
+- 1.8
 before_install:
 - go get github.com/axw/gocov/gocov
 - go get github.com/mattn/goveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.4.2
+FROM golang:1.8
 MAINTAINER Abdulkadir Yaman <abdulkadiryaman@gmail.com>
 
-RUN mkdir /tmp/gopath
-ENV GOPATH /tmp/gopath
+WORKDIR /go/src/app
+COPY . .
 
-RUN go get github.com/yaman/timeout
+RUN go-wrapper download
+RUN go-wrapper install
 
-ENTRYPOINT ${GOPATH}/bin/timeout -proto=$PROTO -port=$PORT
-
+CMD ["go-wrapper", "run"]

--- a/main.go
+++ b/main.go
@@ -5,30 +5,32 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/yaman/timeout/http"
 	"github.com/yaman/timeout/tcp"
 )
 
 func main() {
-	port := os.Getenv("PORT")
 	portParameter := flag.String("port", "8080", "port number to run http from")
-	proto := flag.String("proto", "http", "protocol to run timeouts")
-
+	protoParameter := flag.String("proto", "http", "protocol to run timeouts")
 	flag.Parse()
 
+	port := os.Getenv("PORT")
+	if len(port) == 0 && len(*portParameter) > 0 {
+		port = *portParameter
+	}
+	proto := os.Getenv("PROTO")
+	if len(proto) == 0 && len(*protoParameter) > 0 {
+		proto = *protoParameter
+	}
+
 	switch {
-	case strings.Contains(*proto, "http"):
+	case strings.Contains(proto, "http"):
 
 		fmt.Println("Running Go HTTP Timeout...")
-		if len(port) > 0 {
-			go http.StartRouter(port)
-		} else if portParameter != nil {
-			go http.StartRouter(*portParameter)
-		}
+		go http.StartRouter(port)
 
-	case strings.Contains(*proto, "tcp"):
+	case strings.Contains(proto, "tcp"):
 
 		fmt.Println("Running Go TCP Timeout...")
 		go tcp.ListenAndDoNotAnswer()

--- a/main.go
+++ b/main.go
@@ -42,7 +42,5 @@ func main() {
 		go tcp.ListenAndAnswerEvery30Seconds()
 	}
 
-	for {
-		time.Sleep(10 * time.Second)
-	}
+	select {}
 }


### PR DESCRIPTION
Hi @yaman, 

while setting up integration tests for my project I stumbled over your repository and found it quite useful and would like to use it there. Anyway I had small problems with getting it to work, as the docker image does not listen properly to the SIGTERM signal, because it was using the _shell form_ of the ENTRYPOINT syntax. [Here](https://www.ctl.io/developers/blog/post/gracefully-stopping-docker-containers/) is a quite good article how docker stops and why it doesn't work properly with this _shell form_.

As the setup and the go version 1.4.2 is coming to age, I changed the docker setup to the version 1.8 in the way it is recommended on the golang docker image [here](https://hub.docker.com/_/golang/)(Section: Start a Go instance in your app). To get this working I had to extend the code a bit, so that it can read also the `proto` from the environment and did a minor optimisation with the for-loop.

This way the change is completely compatible, the same docker commands work and from the command line nothing changed. I hope you like the change and you are up to merging this. I would be very happy when you can publish the new version on dockerhub as well. This would make it most easy for me to integrate it in my integration setup. 

Let me know about feedback :) 